### PR TITLE
Correctly intend multiline code examples

### DIFF
--- a/lib/tomparse.rb
+++ b/lib/tomparse.rb
@@ -312,11 +312,11 @@ module TomParse
     def parse_examples(section, sections)
       examples = []
 
-      section = section.sub('Examples', '').strip
+      section = section.sub('Examples', '').gsub(/^\s{2}/,'')
 
       examples << section unless section.empty?
       while sections.first && sections.first !~ /^\S/
-        examples << sections.shift.strip
+        examples << sections.shift.gsub(/^\s{2}/,'')
       end
 
       @examples = examples

--- a/test/test_tomdoc.rb
+++ b/test/test_tomdoc.rb
@@ -72,6 +72,17 @@ comment4
     field - A field name.
 comment5
 
+
+    @comment6 = TomParse::TomDoc.new(<<comment6)
+    # Duplicate some text an abitrary number of times.
+    #
+    # Examples
+    #
+    #   def multiplex(str, length)
+    #     str * length
+    #   end
+comment6
+
   end
 
   test "knows when TomDoc is invalid" do
@@ -118,8 +129,13 @@ comment5
   end
 
   test "knows each example" do
-    assert_equal "multiplex('Bo', 2)\n  # => 'BoBo'",
+    assert_equal "multiplex('Bo', 2)\n# => 'BoBo'",
       @comment.examples[1].to_s
+  end
+
+  test "correctly handles whitespace with examples" do
+    assert_equal "def multiplex(str, length)\n  str * length\nend",
+      @comment6.examples[0].to_s
   end
 
   test "knows what to do when there are no examples" do


### PR DESCRIPTION
```
# Examples
#
#   def multiplex(str, length)
#     str * length
#   end
```

Results currently in (dots shows whitespace):

```
def multiplex(str, length)
....str * length
..end
```

And not:

```
def multiplex(str, length)
..str * length
end
```

I fixed this to #gsub the two \s at the beginning of the line, instead of #strip. Also added one more comment example in the testcase. 
