### PR TITLE
Fix options parsing

### DIFF
--- a/lib/tomparse/parser.rb
+++ b/lib/tomparse/parser.rb
@@ -523,7 +523,7 @@ module TomParse
         next if line.strip.empty?
         indent = line.scan(/^\s*/)[0].to_s.size
 
-        if last_indent && indent > 0 && indent >= last_indent
+        if last_indent && indent > 0 && indent > last_indent
           opts.last.description << "\r\n" + line
         else
           param, desc = line.split(" - ")

--- a/test/test_arguments.rb
+++ b/test/test_arguments.rb
@@ -5,7 +5,7 @@ testcase "Arguments" do
   context "single line argument without heading" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # text - The String to be duplicated.
         #
@@ -25,14 +25,14 @@ testcase "Arguments" do
       @comment.args.first.refute.optional?
     end
     test "know description" do
-      @comment.description == "Duplicate some text an abitrary number of times."
+      @comment.description == "Duplicate some text an arbitrary number of times."
     end
   end
 
   context "multi-line argument without heading" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # text - The String to be duplicated.
         #        And its description continues.
@@ -53,14 +53,14 @@ testcase "Arguments" do
       @comment.args.first.refute.optional?
     end
     test "know description" do
-      @comment.description == "Duplicate some text an abitrary number of times."
+      @comment.description == "Duplicate some text an arbitrary number of times."
     end
   end
 
   context "multiple arguments without heading" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # text - The String to be duplicated.
         #        And its description continues.
@@ -86,14 +86,14 @@ testcase "Arguments" do
       @comment.args[1].assert.optional?
     end
     test "know description" do
-      @comment.description == "Duplicate some text an abitrary number of times."
+      @comment.description == "Duplicate some text an arbitrary number of times."
     end
   end
 
   context "single line argument with heading" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Arguments
         #   text - The String to be duplicated.
@@ -114,14 +114,14 @@ testcase "Arguments" do
       @comment.args.first.refute.optional?
     end
     test "know description" do
-      @comment.description == "Duplicate some text an abitrary number of times."
+      @comment.description == "Duplicate some text an arbitrary number of times."
     end
   end
 
   context "multi-line argument with heading" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Arguments
         #   text - The String to be duplicated.
@@ -143,14 +143,14 @@ testcase "Arguments" do
       @comment.args.first.refute.optional?
     end
     test "know description" do
-      @comment.description == "Duplicate some text an abitrary number of times."
+      @comment.description == "Duplicate some text an arbitrary number of times."
     end
   end
 
   context "multiple arguments without heading" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Arguments
         #   text - The String to be duplicated.
@@ -177,14 +177,14 @@ testcase "Arguments" do
       @comment.args[1].assert.optional?
     end
     test "know description" do
-      @comment.description == "Duplicate some text an abitrary number of times."
+      @comment.description == "Duplicate some text an arbitrary number of times."
     end
   end
 
   context "when description has visibility indicator" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Public: Duplicate some text an abitrary number of times.
+        # Public: Duplicate some text an arbitrary number of times.
         #
         # text - The String to be duplicated.
         #        And its description continues.
@@ -210,7 +210,7 @@ testcase "Arguments" do
       @comment.args[1].refute.optional?
     end
     test "know description" do
-      @comment.description == "Duplicate some text an abitrary number of times."
+      @comment.description == "Duplicate some text an arbitrary number of times."
     end
   end
 

--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -5,7 +5,7 @@ testcase "Examples" do
   context "plural form one example" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Examples
         #   multiplex('Tom', 4)
@@ -27,7 +27,7 @@ testcase "Examples" do
   context "plural form multiple examples" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Examples
         #   multiplex('Tom', 4)
@@ -56,7 +56,7 @@ testcase "Examples" do
   context "singular form" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Example
         #   answer = multiplex('Tom', 4)
@@ -79,7 +79,7 @@ testcase "Examples" do
   context "multiple example clauses" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Examples
         #   multiplex('Tom', 4)
@@ -105,7 +105,7 @@ testcase "Examples" do
   context "handles whitespace in examples" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Examples
         #

--- a/test/test_options.rb
+++ b/test/test_options.rb
@@ -1,0 +1,45 @@
+require_relative 'helper'
+
+testcase "Options" do
+  context "multiple options" do
+    setup do
+      @comment = TomParse::TomDoc.new %{
+        # Duplicate some text an arbitrary number of times.
+        #
+        # text - The String to be duplicated.
+        #
+        # Options
+        #
+        #   works - The Boolean indicating whether this works. Required.
+        #   really_works - The Boolean indicating whether this really works.
+        #
+        # Returns the duplicated String when the count is > 1.
+      }
+    end
+
+    test "converts all options" do
+      @comment.options.size.assert == 2
+    end
+
+    test "knows options names" do
+      @comment.options.map(&:name).assert == [
+        :works,
+        :really_works
+      ]
+    end
+
+    test "knows the options descriptions" do
+      @comment.options.map(&:description).assert == [
+        'The Boolean indicating whether this works. Required.',
+        'The Boolean indicating whether this really works.'
+      ]
+    end
+
+    test "knows the whether the option is required" do
+      @comment.options.map(&:required?).assert == [
+        true,
+        false
+      ]
+    end
+  end
+end

--- a/test/test_signatures.rb
+++ b/test/test_signatures.rb
@@ -6,7 +6,7 @@ testcase "Signatures" do
 
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Signature
         #
@@ -28,7 +28,7 @@ testcase "Signatures" do
 
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Signatures
         #

--- a/test/test_tomdoc.rb
+++ b/test/test_tomdoc.rb
@@ -6,7 +6,7 @@ testcase TomParse::TomDoc do
 
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # text    - The String to be duplicated.
         # count   - The Integer number of times to
@@ -38,7 +38,7 @@ testcase TomParse::TomDoc do
     end
 
     test "parses a description" do
-      @comment.description.assert == "Duplicate some text an abitrary number of times."
+      @comment.description.assert == "Duplicate some text an arbitrary number of times."
     end
 
     test "parses args" do
@@ -126,7 +126,7 @@ testcase TomParse::TomDoc do
   context "handles whitespace in examples" do
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Examples
         #
@@ -146,7 +146,7 @@ testcase TomParse::TomDoc do
 
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Returns the duplicated String.
       }
@@ -171,7 +171,7 @@ testcase TomParse::TomDoc do
 
     setup do
       @comment = TomParse::TomDoc.new %{
-        # Duplicate some text an abitrary number of times.
+        # Duplicate some text an arbitrary number of times.
         #
         # Examples
         #
@@ -196,7 +196,7 @@ testcase TomParse::TomDoc do
 
     setup do
       @comment = TomParse::TomDoc.new %{
-        Duplicate some text an abitrary number of times.
+        Duplicate some text an arbitrary number of times.
   
         Yields the Integer index of the iteration.
         
@@ -209,7 +209,7 @@ testcase TomParse::TomDoc do
     end
 
     test "can handle comments without comment marker" do
-      @comment.description.assert == "Duplicate some text an abitrary number of times."
+      @comment.description.assert == "Duplicate some text an arbitrary number of times."
     end
 
   end

--- a/test/test_yields.rb
+++ b/test/test_yields.rb
@@ -4,7 +4,7 @@ testcase "Yields" do
 
   setup do  
     @comment = TomParse::TomDoc.new %{
-      # Duplicate some text an abitrary number of times.
+      # Duplicate some text an arbitrary number of times.
       #
       # Yields the Integer index of the iteration.
     }


### PR DESCRIPTION
Options parsing for multiple options is currently broken. Only the first option is being parsed and the rest of the comment is being glued on to the end:

```ruby
comment = "
# Duplicate some text an abitrary number of times.
#
# text - The String to be duplicated.
#
# Options
#
#   works - The Boolean indicating whether this works. Required.
#   really_works - The Boolean indicating whether this really works.
#
# Returns the duplicated String when the count is > 1.
"
TomParse.parse(comment).options.first.description
# => "The Boolean indicating whether this works. Required.\r\n  really_works - The Boolean indicating whether this really works.\n"
```

This fixes that and adds the necessary tests.

Also, I fixed a spelling issue (abitrary -> arbitrary).

Cheers! :beers:

